### PR TITLE
Add an exact mode for git-search

### DIFF
--- a/js/components/GitSearch.js
+++ b/js/components/GitSearch.js
@@ -7,30 +7,46 @@ import { renderNodesForLayout, rxFlow, tranformDataForLayout } from './GitCommon
 import { browserHistory } from 'react-router'
 import AppSettings from '../../settings.js';
 
+const MODE_FILE = 'file';
+const MODE_STACKFRAME = 'stackframe';
+const MODE_TOOLTIP = 'Specify the mode to use when searchin\n\n' +
+    `- ${MODE_FILE}: looks up the exact specified filename. Wildcards (*) may be used\n` +
+    `- ${MODE_STACKFRAME}: looks up the file location of a stack element such as Class.throwingMethod() or SomeClass.java:23`;
+
 class SearchBox extends React.Component {
   constructor(props) {
     super(props);
     var query = this.props.location.query || {};
-    this.state = {repo: query.repo || query.project || '^ul', text: query.text || query.grep || '', branch: query.branch || query.ref || 'HEAD', data: [], pending: false};
+    this.state = {repo: query.repo || query.project || '^ul', text: query.text || query.grep || '', branch: query.branch || query.ref || 'HEAD', mode: query.mode || MODE_FILE, data: [], pending: false};
   }
   loadGrepFromServer(params) {
     this.setState({orig: [], data: [], pending: true});
     // parse text to find line_no and stuff
     var txt = params.text;
     var match;
-    var path;
     var line = 1;
-    // TODO: redirect to MS ref src
-    if (match = txt.match(/([\w\.\d]+):(\d+)/)) {
-      path = `*/${match[1]}`;
-      line = match[2];
-    } else if (match = txt.match(/([^.]+)\.[^.]+\(/)) {
-      path = `*/${match[1]}.*`;
-    } else if (match = txt.match(/(\w+)/)) {
-      path = `*/${match[1]}.*`;
+    var paths;
+
+    if (params.mode == MODE_FILE) {
+        paths = [txt, `*/${txt}`]
     }
+    else {
+        var path;
+        // TODO: redirect to MS ref src
+        if (match = txt.match(/([\w\.\d]+):(\d+)/)) {
+        path = `*/${match[1]}`;
+        line = match[2];
+        } else if (match = txt.match(/([^.]+)\.[^.]+\(/)) {
+        path = `*/${match[1]}.*`;
+        } else if (match = txt.match(/(\w+)/)) {
+        path = `*/${match[1]}.*`;
+        }
+        paths = [path]
+    }
+
     var esc = Rx.Observable.fromEvent(document, 'keydown').filter(e => e.keyCode == 27);
-    var rxQty = rxFlow(`${AppSettings.gitRestApi()}/repo/${params.repo}/grep/${params.branch}?q=^&path=${path}&target_line_no=${line}&delimiter=${'%0A%0A'}`, { withCredentials: false })
+    var paths_query = paths.map(function(p) { return `path=${p}` }).join('&')
+    var rxQty = rxFlow(`${AppSettings.gitRestApi()}/repo/${params.repo}/grep/${params.branch}?q=^&${paths_query}&target_line_no=${line}&delimiter=${'%0A%0A'}`, { withCredentials: false })
         .bufferWithTimeOrCount(500, 10)
         .map(elt => this.state.data.concat(elt))
         .map(orig => ({ orig, data: tranformDataForLayout(orig, this.state.layout) }))
@@ -68,6 +84,11 @@ class SearchBox extends React.Component {
             <input name="repo" type="search" placeholder="Matching repos (e.g. ul)" value={this.state.repo} onChange={this.handleAnyChange.bind(this, 'repo')} />
             <input name="text" type="search" placeholder="Search expression" value={this.state.text} onChange={this.handleAnyChange.bind(this, 'text')} />
             <input name="branch" type="search" placeholder="Matching branches (e.g. HEAD)" value={this.state.branch} onChange={this.handleAnyChange.bind(this, 'branch')} />
+            <label for="search_mode" title={MODE_TOOLTIP} >Search mode</label>
+            <select id = "search_mode" title={MODE_TOOLTIP} value={this.state.mode} onChange={this.handleAnyChange.bind(this, 'mode')}>
+               <option value = {MODE_FILE}>{MODE_FILE}</option>
+               <option value = {MODE_STACKFRAME}>{MODE_STACKFRAME}</option>
+             </select>
             <button onClick={this.handleClick.bind(this)}>Search</button>
           </form>
           {loading}

--- a/js/components/GitSearch.js
+++ b/js/components/GitSearch.js
@@ -29,8 +29,7 @@ class SearchBox extends React.Component {
 
     if (params.mode == MODE_FILE) {
         paths = [txt, `*/${txt}`]
-    }
-    else {
+    } else {
         var path;
         // TODO: redirect to MS ref src
         if (match = txt.match(/([\w\.\d]+):(\d+)/)) {
@@ -45,7 +44,7 @@ class SearchBox extends React.Component {
     }
 
     var esc = Rx.Observable.fromEvent(document, 'keydown').filter(e => e.keyCode == 27);
-    var paths_query = paths.map(function(p) { return `path=${p}` }).join('&')
+    var paths_query = paths.map(p => `path=${p}`).join('&');
     var rxQty = rxFlow(`${AppSettings.gitRestApi()}/repo/${params.repo}/grep/${params.branch}?q=^&${paths_query}&target_line_no=${line}&delimiter=${'%0A%0A'}`, { withCredentials: false })
         .bufferWithTimeOrCount(500, 10)
         .map(elt => this.state.data.concat(elt))


### PR DESCRIPTION
- Looking up "build.gradle" in the file mode will now
  return all files named build.gradle without wildcarding
  it, and consider files located at the root of the repository
- The existing behavior is now the 'stackframe' mode which
  allows you to basically locate the file of the element of a
  stacktrace
